### PR TITLE
Add process stubs and update the files to be published

### DIFF
--- a/conf/local.config
+++ b/conf/local.config
@@ -4,8 +4,6 @@ process {
     errorStrategy = 'ignore'
     executor = 'local'
     scratch = true
-    stageInMode = 'copy'
-    stageOutMode = 'copy'
 
     //Resource and module requirements
 

--- a/conf/params.config
+++ b/conf/params.config
@@ -16,4 +16,8 @@ params {
     prokka_reference = ""
     prokka_gram = true
 
+    keep_trimmed_fastq = false
+    keep_shovill_output = false
+
+
 }

--- a/conf/params.config
+++ b/conf/params.config
@@ -17,7 +17,7 @@ params {
     prokka_gram = true
 
     keep_trimmed_fastq = false
-    keep_all_shovill_output = false
+    keep_shovill_output = false
 
 
 }

--- a/conf/params.config
+++ b/conf/params.config
@@ -17,7 +17,7 @@ params {
     prokka_gram = true
 
     keep_trimmed_fastq = false
-    keep_shovill_output = false
+    keep_all_shovill_output = false
 
 
 }

--- a/modules/assembly_stats/assembly_stats.nf
+++ b/modules/assembly_stats/assembly_stats.nf
@@ -9,9 +9,15 @@ process ASSEMBLY_STATS {
     output:
     file("${pair_id}.assembly_stats.txt")
 
+    script:
     """
     statswrapper.sh \
         in=${pair_id}.contigs.fa \
         > ${pair_id}.assembly_stats.txt        
+    """
+
+    stub:
+    """
+    touch ${pair_id}.assembly_stats.txt
     """
 }

--- a/modules/fastp/fastp.nf
+++ b/modules/fastp/fastp.nf
@@ -1,14 +1,14 @@
 
 process FASTP {
     tag { pair_id }
-    publishDir "${params.output_dir}/fastp", mode: 'copy', enabled: params.keep_trimmed_fastq 
+    publishDir "${params.output_dir}/fastp", mode: 'copy', enabled: params.keep_trimmed_fastq
 
     input:
     tuple val(pair_id), path(reads)
 
     output:
     tuple val(pair_id), path("${pair_id}_{1,2}.fastp.fq.gz"), emit: shovill_input
-    path "${pair_id}.json", emit: fastp_reports
+    path "${pair_id}.fastp.json", emit: fastp_reports
 
     script:
     """
@@ -17,7 +17,7 @@ process FASTP {
         --in2 ${reads[1]} \
         --out1 ${pair_id}_1.fastp.fq.gz \
         --out2 ${pair_id}_2.fastp.fq.gz \
-        --json ${pair_id}.json \
+        --json ${pair_id}.fastp.json \
         --html ${pair_id}.html \
         --thread ${task.cpus}
     """
@@ -27,6 +27,6 @@ process FASTP {
     touch ${pair_id}_1.fastp.fq.gz
     touch ${pair_id}_2.fastp.fq.gz
     
-    touch ${pair_id}.json
+    touch ${pair_id}.fastp.json
     """
 }

--- a/modules/fastp/fastp.nf
+++ b/modules/fastp/fastp.nf
@@ -10,6 +10,7 @@ process FASTP {
     tuple val(pair_id), path("${pair_id}_{1,2}.fastp.fq.gz"), emit: shovill_input
     path "${pair_id}.json", emit: fastp_reports
 
+    script:
     """
     fastp \
         --in1 ${reads[0]} \
@@ -19,5 +20,13 @@ process FASTP {
         --json ${pair_id}.json \
         --html ${pair_id}.html \
         --thread ${task.cpus}
+    """
+
+    stub:
+    """
+    touch ${pair_id}_1.fastp.fq.gz
+    touch ${pair_id}_2.fastp.fq.gz
+    
+    touch ${pair_id}.json
     """
 }

--- a/modules/fastp/fastp.nf
+++ b/modules/fastp/fastp.nf
@@ -1,7 +1,7 @@
 
 process FASTP {
     tag { pair_id }
-    publishDir "${params.output_dir}/fastp", mode: 'copy'
+    publishDir "${params.output_dir}/fastp", mode: 'copy', enabled: params.keep_trimmed_fastq 
 
     input:
     tuple val(pair_id), path(reads)

--- a/modules/fastp/fastp.nf
+++ b/modules/fastp/fastp.nf
@@ -1,7 +1,8 @@
 
 process FASTP {
     tag { pair_id }
-    publishDir "${params.output_dir}/fastp", mode: 'copy', enabled: params.keep_trimmed_fastq
+    publishDir "${params.output_dir}/fastp", mode: "copy", pattern: "${pair_id}.fastp.json"
+    publishDir "${params.output_dir}/fastp", mode: "copy", pattern: "*.fastp.fq.gz", enabled: params.keep_trimmed_fastq
 
     input:
     tuple val(pair_id), path(reads)

--- a/modules/multiqc/multiqc.nf
+++ b/modules/multiqc/multiqc.nf
@@ -10,8 +10,12 @@ process MULTIQC {
     path('multiqc_report.html')
 
     script:
-
     """
     multiqc . --filename multiqc_report.html
+    """
+
+    stub:
+    """
+    touch multiqc_report.html
     """
 }

--- a/modules/prokka/prokka.nf
+++ b/modules/prokka/prokka.nf
@@ -63,5 +63,11 @@ process PROKKA {
         ${prokka_species_argument} \
         ${contigs_file}
     """
+
+    stub:
+    """
+    mkdir ${pair_id}_prokka
+    """
+
 }
 

--- a/modules/screen_for_contaminants/screen_for_contaminants.nf
+++ b/modules/screen_for_contaminants/screen_for_contaminants.nf
@@ -28,4 +28,11 @@ process SCREEN_FOR_CONTAMINANTS {
         ${pair_id}_stain_genus_species.tsv
 
     """
+
+    stub:
+    """
+    touch ${pair_id}_stain_genus_species.tsv
+    touch ${pair_id}_contig.fa
+    path "${pair_id}.sendsketch.txt
+    """
 }

--- a/modules/screen_for_contaminants/screen_for_contaminants.nf
+++ b/modules/screen_for_contaminants/screen_for_contaminants.nf
@@ -33,6 +33,6 @@ process SCREEN_FOR_CONTAMINANTS {
     """
     touch ${pair_id}_stain_genus_species.tsv
     touch ${pair_id}_contig.fa
-    path "${pair_id}.sendsketch.txt
+    touch ${pair_id}.sendsketch.txt
     """
 }

--- a/modules/screen_for_contaminants/screen_for_contaminants.nf
+++ b/modules/screen_for_contaminants/screen_for_contaminants.nf
@@ -2,7 +2,7 @@ nextflow.enable.dsl = 2
 
 process SCREEN_FOR_CONTAMINANTS {
     tag { pair_id }
-    publishDir "${params.output_dir}/sendsketch", mode: 'copy'
+    publishDir "${params.output_dir}/sendsketch", mode: 'copy', pattern: "${pair_id}.sendsketch.txt"
 
     input:
     tuple val(pair_id), path(contigs_file)

--- a/modules/shovill/shovill.nf
+++ b/modules/shovill/shovill.nf
@@ -1,7 +1,7 @@
 
 process SHOVILL {
     tag { pair_id }
-    publishDir "${params.output_dir}/shovill", mode: 'copy'
+    publishDir "${params.output_dir}/shovill", mode: 'copy', pattern: "${pair_id}_shovill/*"
 
     input:
     tuple val(pair_id), path(reads)

--- a/modules/shovill/shovill.nf
+++ b/modules/shovill/shovill.nf
@@ -10,6 +10,7 @@ process SHOVILL {
     tuple val(pair_id), path("${pair_id}.contigs.fa")
     path("${pair_id}_shovill/*.{fasta,fastg,log,fa,gfa,changes,hist,tab}")
 
+    script:
     """
     shovill \
          --depth ${params.shovill_depth} \
@@ -19,5 +20,20 @@ process SHOVILL {
          --R2 ${reads[1]} \
          --outdir ${pair_id}_shovill
     cp ${pair_id}_shovill/contigs.fa ${pair_id}.contigs.fa
+    """
+
+    stub:
+    """
+    touch ${pair_id}.contigs.fa
+
+    mkdir ${pair_id}_shovill/
+    touch ${pair_id}_shovill/${pair_id}.fasta
+    touch ${pair_id}_shovill/${pair_id}.fastg
+    touch ${pair_id}_shovill/${pair_id}.log
+    touch ${pair_id}_shovill/${pair_id}.fa
+    touch ${pair_id}_shovill/${pair_id}.gfa
+    touch ${pair_id}_shovill/${pair_id}.changes
+    touch ${pair_id}_shovill/${pair_id}.hist
+    touch ${pair_id}_shovill/${pair_id}.tab
     """
 }

--- a/modules/shovill/shovill.nf
+++ b/modules/shovill/shovill.nf
@@ -1,7 +1,7 @@
 
 process SHOVILL {
     tag { pair_id }
-    publishDir "${params.output_dir}/shovill", mode: 'copy', pattern: "${pair_id}_shovill/*", enabled: params.keep_all_shovill_output
+    publishDir "${params.output_dir}/shovill", mode: 'copy', pattern: "${pair_id}_shovill/*", enabled: params.keep_shovill_output
 
     input:
     tuple val(pair_id), path(reads)

--- a/modules/shovill/shovill.nf
+++ b/modules/shovill/shovill.nf
@@ -19,13 +19,12 @@ process SHOVILL {
          --R1 ${reads[0]} \
          --R2 ${reads[1]} \
          --outdir ${pair_id}_shovill
+
     cp ${pair_id}_shovill/contigs.fa ${pair_id}.contigs.fa
     """
 
     stub:
     """
-    touch ${pair_id}.contigs.fa
-
     mkdir ${pair_id}_shovill/
     touch ${pair_id}_shovill/${pair_id}.fasta
     touch ${pair_id}_shovill/${pair_id}.fastg
@@ -35,5 +34,7 @@ process SHOVILL {
     touch ${pair_id}_shovill/${pair_id}.changes
     touch ${pair_id}_shovill/${pair_id}.hist
     touch ${pair_id}_shovill/${pair_id}.tab
+
+    touch ${pair_id}.contigs.fa
     """
 }

--- a/modules/shovill/shovill.nf
+++ b/modules/shovill/shovill.nf
@@ -1,7 +1,7 @@
 
 process SHOVILL {
     tag { pair_id }
-    publishDir "${params.output_dir}/shovill", mode: 'copy', pattern: "${pair_id}_shovill/*"
+    publishDir "${params.output_dir}/shovill", mode: 'copy', pattern: "${pair_id}_shovill/*", enabled: params.keep_shovill_output
 
     input:
     tuple val(pair_id), path(reads)

--- a/modules/shovill/shovill.nf
+++ b/modules/shovill/shovill.nf
@@ -1,7 +1,7 @@
 
 process SHOVILL {
     tag { pair_id }
-    publishDir "${params.output_dir}/shovill", mode: 'copy', pattern: "${pair_id}_shovill/*", enabled: params.keep_shovill_output
+    publishDir "${params.output_dir}/shovill", mode: 'copy', pattern: "${pair_id}_shovill/*", enabled: params.keep_all_shovill_output
 
     input:
     tuple val(pair_id), path(reads)

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,7 @@ manifest {
     homePage = 'https://bactpipe.readthedocs.io'
     description = 'BACTpipe - whole genome assembly, species identification and annotation pipeline'
     mainScript = 'bactpipe.nf'
-    nextflowVersion = '>=19.10.0'
+    nextflowVersion = '>20.10.0'
 }
 
 report {


### PR DESCRIPTION
@thorellk @emilio-r @boulund 

I've merged the solution for https://github.com/ctmrbio/BACTpipe/issues/132 with the [stub](https://www.nextflow.io/docs/edge/process.html#stub) feature which allows us to test the process flow and file operations without running the underlying softwares and opens up the way for faster iterations on the pipeline.


Just wanted to confirm one thing, you don't have any contstraints regarding updating the `nextflow` versions on your HPC right?