### PR TITLE
Update bactpipe.nf for Nextflow v2 parser compatibility

### DIFF
--- a/bactpipe.nf
+++ b/bactpipe.nf
@@ -4,19 +4,6 @@
 nextflow.enable.dsl = 2
 
 //================================================================================
-// Log info
-//================================================================================
-
-log.info "".center(60, "=")
-log.info "BACTpipe".center(60)
-log.info "Version $workflow.manifest.version".center(60)
-log.info "Bacterial whole genome analysis pipeline".center(60)
-log.info "https://bactpipe.readthedocs.io".center(60)
-log.info "".center(60, "=")
-
-params.help = false
-
-//================================================================================
 // Include modules and (soft) override module-level parameters
 //================================================================================
 
@@ -29,62 +16,85 @@ include { MULTIQC } from "./modules/multiqc/multiqc.nf"
 include { printHelp; printSettings } from "./modules/utils/utils.nf"
 
 //================================================================================
-// Pre-flight checks and info
+// Workflow
 //================================================================================
-
-if (workflow['profile'] in params.profiles_that_require_project) {
-    if (!params.project) {
-        log.error "BACTpipe requires that you set the 'project' parameter when running the ${workflow['profile']} profile.\n".center(60) +
-                "Specify --project <project_name> on the command line, or add it to a custom configuration file.".center(60) + 
-                "Refer to the official docs for more information."
-        exit(1)
-    }
-}
-
-if (params.help) {
-    printHelp()
-    exit(0)
-}
-
-printSettings()
-
-if ( ! params.kraken2_db ) {
-	log.warn "No Kraken2 database specified. Use --kraken2_db /path/to/db to use Kraken2 to classify samples and determine gram stain."
-}
-
-if ( ! params.reads ) {
-    log.error "No reads specified. It is required to specify --reads 'path/to/*_{1,2}.fastq.gz' (note the single quotes)"
-    exit(1)
-}
-
-//================================================================================
-// Prepare channels
-//================================================================================
-
-fastp_input = Channel.fromFilePairs(params.reads)
-
-fastp_input
-        .ifEmpty {
-            log.error "Cannot find any reads matching: '${params.reads}'\n\n" +
-                    "Did you specify --reads 'path/to/*_{1,2}.fastq.gz'? (note the single quotes)\n" +
-                    "Specify --help for a summary of available commands. " +
-                    "Refer to the official docs for more information."
-            printHelp()
-            exit(1)
-        }
-
-//================================================================================
-// Main workflow
-//================================================================================
-
 
 workflow {
+
+    // ============================================================================
+    // Log info
+    // ============================================================================
+    
+    log.info "".center(60, "=")
+    log.info "BACTpipe".center(60)
+    log.info "Version ${workflow.manifest.version}".center(60)
+    log.info "Bacterial whole genome analysis pipeline".center(60)
+    log.info "https://bactpipe.readthedocs.io".center(60)
+    log.info "".center(60, "=")
+
+    // ============================================================================
+    // Pre-flight checks and info
+    // ============================================================================
+    
+    if (workflow['profile'] in params.profiles_that_require_project) {
+        if (!params.project) {
+            log.error(
+                "BACTpipe requires that you set the 'project' parameter when running the ${workflow['profile']} profile.\n".center(60) +
+                "Specify --project <project_name> on the command line, or add it to a custom configuration file.".center(60) +
+                "Refer to the official docs for more information."
+            )
+            exit(1)
+        }
+    }
+
+    if (params.help) {
+        printHelp()
+        exit(0)
+    }
+
+    printSettings()
+
+    if (!params.kraken2_db) {
+        log.warn "No Kraken2 database specified. Use --kraken2_db /path/to/db to use Kraken2 to classify samples and determine gram stain."
+    }
+
+    if (!params.reads) {
+        log.error "No reads specified. It is required to specify --reads 'path/to/*_{1,2}.fastq.gz' (note the single quotes)"
+        exit(1)
+    }
+
+    // ============================================================================
+    // Prepare channels
+    // ============================================================================
+    
+    fastp_input = channel.fromFilePairs(params.reads)
+
+    fastp_input.ifEmpty {
+        log.error(
+            "Cannot find any reads matching: '${params.reads}'\n\n" +
+            "Did you specify --reads 'path/to/*_{1,2}.fastq.gz'? (note the single quotes)\n" +
+            "Specify --help for a summary of available commands. " +
+            "Refer to the official docs for more information."
+        )
+        printHelp()
+        exit(1)
+    }
+
+    // ============================================================================
+    // Main workflow
+    // ============================================================================
+    
     FASTP(fastp_input)
+
     CLASSIFY_TAXONOMY(FASTP.out.fastq)
+
     SHOVILL(FASTP.out.fastq)
+
     ASSEMBLY_STATS(SHOVILL.out.contigs)
 
-    prokka_ch = (SHOVILL.out.contigs).join(CLASSIFY_TAXONOMY.out.classification)
+    prokka_ch = SHOVILL.out.contigs.join(
+        CLASSIFY_TAXONOMY.out.classification
+    )
 
     PROKKA(prokka_ch)
 
@@ -92,22 +102,20 @@ workflow {
         FASTP.out.fastp_reports.collect(),
         PROKKA.out.collect()
     )
+
+    // ============================================================================
+    // Workflow handlers
+    // ============================================================================
+    
+    workflow.onComplete = {
+        log.info "".center(60, "=")
+        log.info "BACTpipe workflow completed without errors".center(60)
+        log.info "Check output files in folder:".center(60)
+        log.info "${params.output_dir}".center(60)
+        log.info "".center(60, "=")
+    }
+
+    workflow.onError = {
+        println "Oops... Pipeline execution stopped with the following message: ${workflow.errorMessage}".center(60, "=")
+    }
 }
-
-//================================================================================
-// Workflow onComplete action
-//================================================================================
-
-workflow.onComplete {
-    log.info "".center(60, "=")
-    log.info "BACTpipe workflow completed without errors".center(60)
-    log.info "Check output files in folder:".center(60)
-    log.info "${params.output_dir}".center(60)
-    log.info "".center(60, "=")
-}
-
-
-workflow.onError {
-    println "Oops... Pipeline execution stopped with the following message: ${workflow.errorMessage}".center(60, "=")
-}
-

--- a/conf/dardel.config
+++ b/conf/dardel.config
@@ -43,7 +43,7 @@ process {
     }
 
     withName: 'PROKKA' {
-        container = 'staphb/prokka:1.15.6--pl5321hdfd78af_0'
+        container = 'https://depot.galaxyproject.org/singularity/prokka:1.15.6--pl5321hdfd78af_0'
         cpus = 12
         time = 10.m
     }

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -36,7 +36,7 @@ BACTpipe is published as open source under the MIT license and you are welcome
 to look at, suggest improvements, or download and improve/contribute to the code
 at the project's `Github repository`_ page.
 
-.. _Github repository: https://github.com/ctmrbio/BACTpipe
+.. _Github repository: https://github.com/KThorellGroup/BACTpipe
 
 
 Contributing
@@ -51,7 +51,7 @@ If you find BACTpipe useful and publish something using BACTpipe, please cite:
 
 | Emilio Rudbeck; Abhinav Sharma; Joseph Kirangwa; Yue Hu; Sandra Álvarez-Carretero; Fredrik Boulund; Kaisa Thorell (2017-2021).
 | BACTpipe: bacterial whole genome sequence assembly and annotation pipeline.
-| https://github.com/ctmrbio/BACTpipe
+| https://github.com/KThorellGroup/BACTpipe
 | DOI: https://doi.org/10.5281/zenodo.4742358
 
 .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.4742358.svg

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -7,15 +7,14 @@ Dependencies
 In order to run `BACTpipe`_, you need to have the following programs installed:
 
 - `Java v8+`_ for Nextflow 
-- `Nextflow`_ for workflow management, more specifically `v21.04.0`_
+- `Nextflow`_ for workflow management, more specifically `v26.04.0`_
 - `Conda`_ for installation of workflow tools
 - (Optional) A `Kraken2 database`_ if you want to classify taxonomy and gram
   stain to potentially improve genome annotations in the Prokka step.
 
-.. _BACTpipe: https://github.com/ctmrbio/BACTpipe
+.. _BACTpipe: https://github.com/KThorellGroup/BACTpipe
 .. _Java v8+: https://www.java.com/sv/download/help/download_options.xml
 .. _Nextflow: https://www.nextflow.io/
-.. _v21.04.0: https://github.com/nextflow-io/nextflow/releases/download/v21.04.0/nextflow-21.04.0-all
 .. _Conda: https://docs.conda.io/en/latest/
 .. _Kraken2 database: http://ccb.jhu.edu/software/kraken2/index.shtml?t=downloads
 

--- a/docs/source/running.rst
+++ b/docs/source/running.rst
@@ -4,9 +4,9 @@ After installing all the required dependencies and downloading the required
 mash sketches of refseq genomes, it is very easy to run BACTpipe. There are
 several ways to run BACTpipe, but we'll start with the easiest::
 
-    $ nextflow run ctmrbio/BACTpipe --reads 'path/to/reads/*_R{1,2}.fastq.gz'
+    $ nextflow run KThorellGroup/BACTpipe --reads 'path/to/reads/*_R{1,2}.fastq.gz'
 
-This will instruct Nextflow to go to the ``ctmrbio`` Github organization to
+This will instruct Nextflow to go to the ``KThorellGroup`` Github organization to
 download and run the ``BACTpipe`` workflow. The argument ``--reads`` is used to
 tell the workflow which input files you want to run BACTpipe on. Note that the
 path to the reads must be enclosed in single quotes (``'``) to prevent the
@@ -24,7 +24,7 @@ file suffixes).
     to your computer. If BACTpipe is updated after your first run, the 
     subsequent runs will still use the old version that you have downloaded.
     To get the newest version, tell Nextflow to update your local copy:
-    ``nextflow pull ctmrbio/BACTpipe``.
+    ``nextflow pull KThorellGroup/BACTpipe``.
 
 When BACTpipe is run like this, it by default assumes you want to run
 everything locally, on the current machine.  Note that BACTpipe is capable of
@@ -39,7 +39,7 @@ your purpose. It is possible to modify several settings for how BACTpipe
 operates using configuration parameters. All changes can be added as
 command-line arguments when running BACTpipe, e.g.::
 
-    $ nextflow run ctmrbio/BACTpipe --prokka_evalue 1e-24 --reads 'path/to/reads/*_{1,2}.fastq.gz'
+    $ nextflow run KThorellGroup/BACTpipe --prokka_evalue 1e-24 --reads 'path/to/reads/*_{1,2}.fastq.gz'
 
 The ``--prokka_evalue`` flag will modify the kmer lengths that `prokka`_ will
 use when blasting for annotation. The following parameters can be easily configured
@@ -70,7 +70,7 @@ command line when running BACTpipe, e.g. ``--shovill_depth 75`` to set
 the ``conf`` directory of the `BACTpipe repository`_ for a complete up-to-date
 listing of all available parameters. 
 
-.. _BACTpipe repository: https://www.github.com/ctmrbio/BACTpipe
+.. _BACTpipe repository: https://www.github.com/KThorellGroup/BACTpipe
 
 Change many settings at once
 ............................
@@ -93,7 +93,7 @@ If you save the above into a plain text file called ``custom_bactpipe_config.yam
 you can provide it when running BACTpipe using the ``-params-file`` command 
 line argument::
 
-    $ nextflow run ctmrbio/BACTpipe -params-file path/to/your/custom/params.yaml --reads 'path/to/reads/*_{1,2}.fastq.gz'
+    $ nextflow run KThorellGroup/BACTpipe -params-file path/to/your/custom/params.yaml --reads 'path/to/reads/*_{1,2}.fastq.gz'
 
 There is also another way to modify parameters that uses Nextflow's own
 configuration format. This can be useful if you want to modify *a lot* of
@@ -104,9 +104,9 @@ file contains some comments explaining how the different variables work, to
 help out when modifying the settings. To run BACTpipe with a custom
 configuration in the Nextflow format, you use ``-c`` on the command line::
 
-    $ nextflow run ctmrbio/BACTpipe -c path/to/custom_params.config --reads 'path/to/reads/*_{1,2}.fastq.gz'
+    $ nextflow run KThorellGroup/BACTpipe -c path/to/custom_params.config --reads 'path/to/reads/*_{1,2}.fastq.gz'
 
-.. _params.config: https://github.com/ctmrbio/BACTpipe/blob/master/conf/params.config
+.. _params.config: https://github.com/KThorellGroup/BACTpipe/blob/master/conf/params.config
 
 Note:
 ............................
@@ -135,7 +135,7 @@ load a profile. BACTpipe comes with a few pre-installed profiles:
 And the now deprecated:
 
 * ``ctmr_nas`` -- For local execution on CTMR's old analysis server.
-* ``ctmr_gandalf`` -- For use on CTMR's Gandalf Slurm HPC system.
+* ``ctmr_gandalf`` -- For use on CTMR's old Gandalf Slurm HPC system.
 * ``rackham`` -- For use on the UPPMAX's Rackham HPC system.
 
 
@@ -151,7 +151,7 @@ And the now deprecated:
 To run BACTpipe with a specific profile, use the ``-profile <profilename>``
 argument (note the single dash before ``profile``) when running, e.g.::
 
-    $ nextflow run ctmrbio/BACTpipe -profile dardel --project SNIC001 --reads '/proj/projectname/reads/*_{1,2}.fastq.gz'
+    $ nextflow run KThorellGroup/BACTpipe -profile dardel --project SNIC001 --reads '/proj/projectname/reads/*_{1,2}.fastq.gz'
 
 This will run BACTpipe using the ``dardel`` profile with the project set to
 ``SNIC001``, which automatically configures settings so BACTpipe can download
@@ -170,17 +170,17 @@ pre-defined expected CPU, memory, and time requirements for processes on the
 cluster. The best way to start is probably to download one of the pre-existing
 profiles from `conf directory`_ of the `BACTpipe repository`_. 
 
-.. _conf directory: https://github.com/ctmrbio/BACTpipe/tree/master/conf
+.. _conf directory: https://github.com/KThorellGroup/BACTpipe/tree/master/conf
 
-If you are working on a Slurm-managed system, starting with either the
-``dardel.config`` or the ``ctmr_gandalf`` profile would be a good choice, as
-both of those are Slurm-managed HPC systems. Download the configuration file
+If you are working on a Slurm-managed system, starting with the
+``dardel.config`` profile would be a good choice, as
+this is a Slurm-managed HPC system. Download the configuration file
 from the `conf directory`_ of the `BACTpipe repository`_ and modify settings to
 your preference. Then, to run BACTpipe using your custom configuration file,
 you need to tell Nextflow to read parameters from your file instead of the
 default parameters::
 
-    $ nextflow run ctmrbio/BACTpipe -c path/to/your/custom/profile.config --reads 'path/to/reads/*_{1,2}.fastq.gz'
+    $ nextflow run KThorellGroup/BACTpipe -c path/to/your/custom/profile.config --reads 'path/to/reads/*_{1,2}.fastq.gz'
 
 The custom profile is not limited to configuring CPU, memory and time limits
 for the different processes. It is also possible to set parameter values inside
@@ -188,5 +188,3 @@ the custom profile, i.e. to change paths to reference databases or adjust
 runtime parameters for the different processes. It is also possible to just use
 a configuration file that changes settings without modifying how the workflow
 is run, see :ref:`Change many settings at once`.
-
-

--- a/modules/assembly_stats/assembly_stats.nf
+++ b/modules/assembly_stats/assembly_stats.nf
@@ -1,19 +1,19 @@
-
 process ASSEMBLY_STATS {
-    tag { pair_id }
+    tag "$pair_id"
+
     publishDir "${params.output_dir}/shovill", mode: 'copy'
 
     input:
-    tuple val(pair_id), file("${pair_id}.contigs.fa")
+    tuple val(pair_id), path(contigs_file)
 
     output:
-    file("${pair_id}.assembly_stats.txt")
+    path "${pair_id}.assembly_stats.txt"
 
     script:
     """
     statswrapper.sh \
-        in=${pair_id}.contigs.fa \
-        > ${pair_id}.assembly_stats.txt        
+        in=${contigs_file} \
+        > ${pair_id}.assembly_stats.txt
     """
 
     stub:

--- a/modules/classify_taxonomy/classify_taxonomy.nf
+++ b/modules/classify_taxonomy/classify_taxonomy.nf
@@ -1,43 +1,42 @@
-nextflow.enable.dsl = 2
-
 process CLASSIFY_TAXONOMY {
-    tag { pair_id }
+    tag "$pair_id"
+
     publishDir "${params.output_dir}/kraken2", mode: 'copy'
-    
+
     input:
     tuple val(pair_id), path(reads)
 
     output:
-    path("${pair_id}.kreport")
-    tuple val("${pair_id}"), path("${pair_id}.classification.txt"), emit: classification
+    path "${pair_id}.kreport"
+    tuple val(pair_id), path("${pair_id}.classification.txt"), emit: classification
 
     script:
-	if ( params.kraken2_db ) {
-		"""
-		kraken2 \
-			--quick \
-			--db ${params.kraken2_db} \
-			--threads ${task.cpus} \
-			--confidence ${params.kraken2_confidence} \
-			--output - \
-			--report ${pair_id}.kreport \
-			--use-names \
-			--paired \
-			${reads[0]} ${reads[1]}
-		
-		classify_kreport.py \
-			--kreport ${pair_id}.kreport \
-			--min-proportion ${params.kraken2_min_proportion} \
-			--gramstains ${projectDir}/resources/gram_stain.txt \
-			> ${pair_id}.classification.txt
-		"""
-	}
+    if (params.kraken2_db) {
+        """
+        kraken2 \
+            --quick \
+            --db ${params.kraken2_db} \
+            --threads ${task.cpus} \
+            --confidence ${params.kraken2_confidence} \
+            --output - \
+            --report ${pair_id}.kreport \
+            --use-names \
+            --paired \
+            ${reads[0]} ${reads[1]}
+
+        classify_kreport.py \
+            --kreport ${pair_id}.kreport \
+            --min-proportion ${params.kraken2_min_proportion} \
+            --gramstains ${projectDir}/resources/gram_stain.txt \
+            > ${pair_id}.classification.txt
+        """
+    }
     else {
-		"""
-    	touch ${pair_id}.kreport
+        """
+        touch ${pair_id}.kreport
         echo "Unknown\tunknown\tUnknown" > ${pair_id}.classification.txt
-    	"""
-	}
+        """
+    }
 
     stub:
     """

--- a/modules/fastp/fastp.nf
+++ b/modules/fastp/fastp.nf
@@ -1,8 +1,14 @@
-
 process FASTP {
-    tag { pair_id }
-    publishDir "${params.output_dir}/fastp", mode: "copy", pattern: "${pair_id}.fastp.json"
-    publishDir "${params.output_dir}/fastp", mode: "copy", pattern: "*.fastp.fq.gz", enabled: params.keep_trimmed_fastq
+    tag "$pair_id"
+
+    publishDir "${params.output_dir}/fastp",
+        mode: "copy",
+        pattern: "${pair_id}.fastp.json"
+
+    publishDir "${params.output_dir}/fastp",
+        mode: "copy",
+        pattern: "*.fastp.fq.gz",
+        enabled: params.keep_trimmed_fastq
 
     input:
     tuple val(pair_id), path(reads)
@@ -27,7 +33,6 @@ process FASTP {
     """
     touch ${pair_id}_1.fastp.fq.gz
     touch ${pair_id}_2.fastp.fq.gz
-    
     touch ${pair_id}.fastp.json
     """
 }

--- a/modules/fastp/fastp.nf
+++ b/modules/fastp/fastp.nf
@@ -3,7 +3,7 @@ process FASTP {
 
     publishDir "${params.output_dir}/fastp",
         mode: "copy",
-        pattern: "${pair_id}.fastp.json"
+        pattern: "*.fastp.json"
 
     publishDir "${params.output_dir}/fastp",
         mode: "copy",

--- a/modules/prokka/prokka.nf
+++ b/modules/prokka/prokka.nf
@@ -1,50 +1,53 @@
-nextflow.enable.dsl = 2
-
 process PROKKA {
-    tag { pair_id }
+    tag "$pair_id"
+
     publishDir "${params.output_dir}/prokka", mode: 'copy'
 
     input:
-    tuple val(pair_id), path(contigs_file), path(classification)
+    tuple val(pair_id), path(contigs_file), path(classification_file)
 
     output:
-    path("${pair_id}_prokka")
+    path "${pair_id}_prokka"
 
     script:
-    prokka_reference_argument = ""
-    if( params.prokka_reference ) {
+    def prokka_reference_argument = ""
+    if (params.prokka_reference) {
         prokka_reference_argument = "--proteins ${params.prokka_reference}"
     }
 
-    classification = file(classification.resolveSymLink()).getText().split("\t")
-	genus = classification[0]
-	species = classification[1]
-	gramstain = classification[2]
+    def classification_data =
+        file(classification_file.resolveSymLink()).getText().split("\t")
 
-    prokka_gramstain_argument = ""
-    if( params.prokka_signal_peptides ) {
-        if( gramstain == "pos" ) {
+    def genus = classification_data[0]
+    def species = classification_data[1]
+    def gramstain = classification_data[2]
+
+    def prokka_gramstain_argument = ""
+    if (params.prokka_signal_peptides) {
+        if (gramstain == "pos") {
             prokka_gramstain_argument = "--gram pos"
-        } else if( gramstain == "neg" ) {
+        }
+        else if (gramstain == "neg") {
             prokka_gramstain_argument = "--gram neg"
-        } else {
-            prokka_gramstain_argument = ""
         }
     }
 
-    prokka_genus_argument = ""
-    if( genus == "Unknown" ) {
+    def prokka_genus_argument
+    if (genus == "Unknown") {
         prokka_genus_argument = "--genus Unknown"
-    } else if ( genus == "Mixed" ) {
+    }
+    else if (genus == "Mixed") {
         prokka_genus_argument = "--genus Mixed"
-    } else {
+    }
+    else {
         prokka_genus_argument = "--genus ${genus}"
     }
 
-    prokka_species_argument = ""
-    if( species == "unknown" || species == "spp." ) {
+    def prokka_species_argument
+    if (species == "unknown" || species == "spp.") {
         prokka_species_argument = "--species Unknown"
-    } else {
+    }
+    else {
         prokka_species_argument = "--species ${species}"
     }
 
@@ -69,6 +72,4 @@ process PROKKA {
     """
     mkdir ${pair_id}_prokka
     """
-
 }
-

--- a/modules/shovill/shovill.nf
+++ b/modules/shovill/shovill.nf
@@ -1,30 +1,36 @@
-
 process SHOVILL {
-    tag { pair_id }
-    publishDir "${params.output_dir}/shovill", mode: 'copy', pattern: "${pair_id}_shovill/*.log"
-    publishDir "${params.output_dir}/shovill", mode: 'copy', pattern: "${pair_id}_shovill/*.{fasta,fastg,fa,gfa,changes,hist,tab}", enabled: params.keep_shovill_output
+    tag "$pair_id"
+
+    publishDir "${params.output_dir}/shovill",
+        mode: 'copy',
+        pattern: "${pair_id}_shovill/*.log"
+
+    publishDir "${params.output_dir}/shovill",
+        mode: 'copy',
+        pattern: "${pair_id}_shovill/*.{fasta,fastg,fa,gfa,changes,hist,tab}",
+        enabled: params.keep_shovill_output
 
     input:
     tuple val(pair_id), path(reads)
 
     output:
     tuple val(pair_id), path("${pair_id}_contigs.fa"), emit: contigs
-    path("${pair_id}_shovill/*.{fasta,fastg,log,fa,gfa,changes,hist,tab}")
+    path "${pair_id}_shovill/*.{fasta,fastg,log,fa,gfa,changes,hist,tab}"
 
     script:
     """
     shovill \
-         --depth ${params.shovill_depth} \
-         --minlen ${params.shovill_minlen} \
-         --cpus ${task.cpus} \
-         --R1 ${reads[0]} \
-         --R2 ${reads[1]} \
-         --outdir ${pair_id}_shovill
+        --depth ${params.shovill_depth} \
+        --minlen ${params.shovill_minlen} \
+        --cpus ${task.cpus} \
+        --R1 ${reads[0]} \
+        --R2 ${reads[1]} \
+        --outdir ${pair_id}_shovill
 
     rename_fasta.py \
-		--input ${pair_id}_shovill/contigs.fa \
-		--output ${pair_id}_contigs.fa \
-		--pre ${pair_id}_contig
+        --input ${pair_id}_shovill/contigs.fa \
+        --output ${pair_id}_contigs.fa \
+        --pre ${pair_id}_contig
     """
 
     stub:
@@ -38,7 +44,6 @@ process SHOVILL {
     touch ${pair_id}_shovill/${pair_id}.changes
     touch ${pair_id}_shovill/${pair_id}.hist
     touch ${pair_id}_shovill/${pair_id}.tab
-
     touch ${pair_id}_contigs.fa
     """
 }

--- a/modules/shovill/shovill.nf
+++ b/modules/shovill/shovill.nf
@@ -3,11 +3,11 @@ process SHOVILL {
 
     publishDir "${params.output_dir}/shovill",
         mode: 'copy',
-        pattern: "${pair_id}_shovill/*.log"
+        pattern: "*_shovill/*.log"
 
     publishDir "${params.output_dir}/shovill",
         mode: 'copy',
-        pattern: "${pair_id}_shovill/*.{fasta,fastg,fa,gfa,changes,hist,tab}",
+        pattern: "*_shovill/*.{fasta,fastg,fa,gfa,changes,hist,tab}",
         enabled: params.keep_shovill_output
 
     input:

--- a/modules/utils/utils.nf
+++ b/modules/utils/utils.nf
@@ -24,11 +24,12 @@ def printHelp() {
 
 def printSettings() {
     log.info "Running with the following settings:".center(60)
-    for (option in params) {
-        if (option.key in ['cluster-options', 'help', 'profiles_that_require_project']) {
-            continue
+
+    params.each { key, value ->
+        if (!(key in ['clusterOptions', 'help', 'profiles_that_require_project'])) {
+            log.info "${key}: ".padLeft(30) + "${value}"
         }
-        log.info "${option.key}: ".padLeft(30) + "${option.value}"
     }
+
     log.info "".center(60, "=")
 }

--- a/modules/utils/utils.nf
+++ b/modules/utils/utils.nf
@@ -2,7 +2,7 @@
 def printHelp() {
     log.info """
   Example usage:
-    nextflow run ctmrbio/BACTpipe --reads '*_R{1,2}.fastq.gz'
+    nextflow run KThorellGroup/BACTpipe --reads '*_R{1,2}.fastq.gz'
 
   Mandatory arguments:
     --reads                 Path to input data (must be surrounded with single quotes).

--- a/nextflow.config
+++ b/nextflow.config
@@ -25,14 +25,6 @@ profiles {
         includeConfig 'conf/params.config'
         includeConfig 'conf/local.config'
     }
-    ctmr_nas {
-        includeConfig 'conf/params.config'
-        includeConfig 'conf/ctmr_nas.config'
-    }
-    ctmr_gandalf {
-        includeConfig 'conf/params.config'
-        includeConfig 'conf/ctmr_gandalf.config'
-    }
     rackham {
         includeConfig 'conf/params.config'
         includeConfig 'conf/rackham.config'

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,8 +5,8 @@ manifest {
     homePage = 'https://bactpipe.readthedocs.io'
     description = 'BACTpipe - whole genome assembly, species identification and annotation pipeline'
     mainScript = 'bactpipe.nf'
-    nextflowVersion = '>=21.04.0'
-    version = '3.1.0'
+    nextflowVersion = '!>=26.04.0'
+    version = '3.2.0'
 }
 
 report {


### PR DESCRIPTION
Restructure the main BACTpipe workflow for compatibility with the Nextflow v2 syntax parser introduced as the default in Nextflow 26.04.

- Move top-level executable statements into the workflow block.
- Move startup logging and parameter validation into the workflow.
- Move input channel creation into the workflow.
- Update workflow completion and error handlers to workflow-scoped closure syntax.
- Use the lowercase `channel` factory for input channel creation.
- Move the default `help` parameter to the parameter configuration.
- Preserve the existing pipeline execution order and behaviour.

These changes address v2 parser errors caused by mixing executable statements with script declarations while retaining the existing DSL2 workflow structure.